### PR TITLE
Fix ruby worker with ruby 1.9 & non-latin characters.

### DIFF
--- a/priv/worker.rb
+++ b/priv/worker.rb
@@ -72,8 +72,9 @@ def handle_request(app, env)
     end
   
     t = ary.join("")
+    packed_t = [t].pack('a*')
   
-    [0, t.size, t].pack("CNa*")
+    [0, packed_t.size].pack("CN") + packed_t
   end
   
   body.close if body.respond_to?(:close)


### PR DESCRIPTION
Ruby 1.8 works fine, for packed and unpacked strings length is equal:
irb(main):002:0> t = 'Raphaël'
"Rapha\303\253l"
irb(main):003:0> t.size
8
irb(main):004:0> [t].pack('a*').size
8

but not for Ruby 1.9, .size for string means count of characters, not size in bytes:
irb(main):022:0> t = 'Raphaël'
=> "Raphaël"
irb(main):023:0> t.size
=> 7
irb(main):024:0> [t].pack('a*').size
=> 8
